### PR TITLE
update sgp30 newer sensors support

### DIFF
--- a/esp32_sgp30.py
+++ b/esp32_sgp30.py
@@ -2,7 +2,7 @@ import time
 from micropython import const
 
 _SGP30_DEFAULT_I2C_ADDR = const(0x58)
-_SGP30_FEATURESET = const(0x0020)
+_SGP30_FEATURESETS = const(0x0020, 0x0022)
 
 _SGP30_CRC8_POLYNOMIAL = const(0x31)
 _SGP30_CRC8_INIT = const(0xFF)
@@ -22,7 +22,7 @@ class SGP30:
         self._addr = address
         self.serial = self._i2c_read_words_from_cmd(command=[0x36, 0x82], reply_size=3, delay=0.01)
         featureset = self._i2c_read_words_from_cmd([0x20, 0x2f], 1, 0.01)
-        if featureset[0] != _SGP30_FEATURESET:
+        if featureset[0] not in _SGP30_FEATURESETS:
             raise RuntimeError('SGP30 Not detected')
         self.initialise_indoor_air_quality()
 

--- a/esp32_sgp30.py
+++ b/esp32_sgp30.py
@@ -2,7 +2,7 @@ import time
 from micropython import const
 
 _SGP30_DEFAULT_I2C_ADDR = const(0x58)
-_SGP30_FEATURESETS = const(0x0020, 0x0022)
+_SGP30_FEATURESETS = (0x0020, 0x0022)
 
 _SGP30_CRC8_POLYNOMIAL = const(0x31)
 _SGP30_CRC8_INIT = const(0xFF)

--- a/esp32_sht31.py
+++ b/esp32_sht31.py
@@ -13,14 +13,14 @@ class SHT31(object):
   # This static map helps keeping the heap and program logic cleaner
   _map_cs_r = {
   	True: {
-      R_HIGH : b'\x2c\x06',
-      R_MEDIUM : b'\x2c\x0d',
-      R_LOW: b'\x2c\x10'
+      R_HIGH : b'\\x2c\\x06',
+      R_MEDIUM : b'\\x2c\\x0d',
+      R_LOW: b'\\x2c\\x10'
       },
     False: {
-      R_HIGH : b'\x24\x00',
-      R_MEDIUM : b'\x24\x0b',
-      R_LOW: b'\x24\x16'
+      R_HIGH : b'\\x24\\x00',
+      R_MEDIUM : b'\\x24\\x0b',
+      R_LOW: b'\\x24\\x16'
       }
     }
 


### PR DESCRIPTION
- Added SGP30 **featuresets** constants for newer sensors compatibility.
- SHT31 syntax: added double backslash to byte string encoding.
